### PR TITLE
Saved search

### DIFF
--- a/CRM/Consentactivity/Config.php
+++ b/CRM/Consentactivity/Config.php
@@ -14,6 +14,7 @@ class CRM_Consentactivity_Config extends CRM_RcBase_Config
         return [
             'activity-type-id' => 0,
             'option-value-id' => 0,
+            'saved-search-id' => 0,
         ];
     }
 }

--- a/CRM/Consentactivity/Service.php
+++ b/CRM/Consentactivity/Service.php
@@ -171,12 +171,27 @@ class CRM_Consentactivity_Service
                 ],
             ],
         ];
-        $results = \Civi\Api4\SavedSearch::create(false)
+        $results = SavedSearch::create(false)
             ->addValue('label', 'Contacts with old consents')
             ->addValue('api_entity', 'Contact')
             ->addValue('api_params', $apiParams)
             ->execute();
         return $results->first();
+    }
+    /*
+     * It is a wrapper function for saved search get api call.
+     *
+     * @param int $savedSearchId
+     *
+     * @return array
+     */
+    public static function getSavedSearch(int $savedSearchId): array
+    {
+        $result = SavedSearch::get(false)
+            ->addWhere('id', '=', $savedSearchId)
+            ->execute()
+            ->first();
+        return $result ?? [];
     }
     /*
      * It returns true if the given form contains field that connected

--- a/CRM/Consentactivity/Service.php
+++ b/CRM/Consentactivity/Service.php
@@ -3,6 +3,7 @@
 use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
 use Civi\Api4\Activity;
+use Civi\Api4\SavedSearch;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 class CRM_Consentactivity_Service
@@ -115,6 +116,65 @@ class CRM_Consentactivity_Service
             ->execute()
             ->first();
         return $result ?? [];
+    }
+    /*
+     * This function creates a saved search, that could be the base query of the
+     * gathering process of the contacts with old consents.
+     *
+     * @param string $activityName
+     *
+     * @return array
+     */
+    public static function savedSearch(string $activityName): array
+    {
+        $apiParams = [
+            'version' => 4,
+            'select' => [
+                'id',
+                'GROUP_CONCAT(Contact_ActivityContact_Activity_01.activity_type_id:label) AS GROUP_CONCAT_Contact_ActivityContact_Activity_01_activity_type_id_label',
+                'MAX(Contact_ActivityContact_Activity_01.created_date) AS MAX_Contact_ActivityContact_Activity_01_created_date',
+            ],
+            'orderBy' => [],
+            'where' => [],
+            'groupBy' => [
+                'id'
+            ],
+            'join' => [
+                [
+                    'Activity AS Contact_ActivityContact_Activity_01',
+                    'INNER',
+                    'ActivityContact',
+                    [
+                        'id',
+                        '=',
+                        'Contact_ActivityContact_Activity_01.contact_id'
+                    ],
+                    [
+                        'Contact_ActivityContact_Activity_01.record_type_id:name',
+                        '=',
+                        '"Activity Source"'
+                    ],
+                    [
+                        'Contact_ActivityContact_Activity_01.activity_type_id:name',
+                        '=',
+                        '"'.$activityName.'"'
+                    ]
+                ],
+            ],
+            'having' => [
+                [
+                    'MAX_Contact_ActivityContact_Activity_01_created_date',
+                    '<',
+                    '2021-06-17 11:50'
+                ],
+            ],
+        ];
+        $results = \Civi\Api4\SavedSearch::create(false)
+            ->addValue('label', 'Contacts with old consents')
+            ->addValue('api_entity', 'Contact')
+            ->addValue('api_params', $apiParams)
+            ->execute();
+        return $results->first();
     }
     /*
      * It returns true if the given form contains field that connected

--- a/CRM/Consentactivity/Upgrader.php
+++ b/CRM/Consentactivity/Upgrader.php
@@ -33,6 +33,8 @@ class CRM_Consentactivity_Upgrader extends CRM_Consentactivity_Upgrader_Base
         $cfg = $config->get();
         $cfg['option-value-id'] = $activityType['id'];
         $cfg['activity-type-id'] = $activityType['value'];
+        $savedSearch = CRM_Consentactivity_Service::savedSearch($activityType['name']);
+        $cfg['saved-search-id'] = $savedSearch['id'];
         $config->update($cfg);
     }
 

--- a/CRM/Consentactivity/Upgrader.php
+++ b/CRM/Consentactivity/Upgrader.php
@@ -92,7 +92,6 @@ class CRM_Consentactivity_Upgrader extends CRM_Consentactivity_Upgrader_Base
      */
     public function upgrade_5000()
     {
-        $this->ctx->log->info('Applying update 5000');
         $config = new CRM_Consentactivity_Config($this->extensionName);
         $config->load();
         $cfg = $config->get();

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension could be used for tracking GDPR related activities. It supports t
 An activity is added to the contact when it fills a form that contains the consent parameters. The date of the activity is the date of the consent. The status of the activity will be completed.
 The activity type is created by the extension. If an existing activity type has to be used, you can make it happen if you change the label of the type to the extension default value, that is `GDPR Consent Activity`.
 
-The search-kit extension could be used for finding the contacts where the last consent activity was more then N years ago. This extension provides a saved search that contains the basic setup. The date field has to be updated in the Having statement.
+The search-kit extension could be used for finding the contacts where the last consent activity was more than N years ago. This extension provides a saved search that contains the basic setup. The date field has to be updated in the Having statement.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This extension could be used for tracking GDPR related activities. It supports t
 An activity is added to the contact when it fills a form that contains the consent parameters. The date of the activity is the date of the consent. The status of the activity will be completed.
 The activity type is created by the extension. If an existing activity type has to be used, you can make it happen if you change the label of the type to the extension default value, that is `GDPR Consent Activity`.
 
+The search-kit extension could be used for finding the contacts where the last consent activity was more then N years ago. This extension provides a saved search that contains the basic setup. The date field has to be updated in the Having statement.
+
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Requirements
@@ -27,8 +29,10 @@ cv en consentactivity
 
 ### Upgrader
 
-When the extension is installed, it creates the default setting. During the postInstall step, it searches for an activity type that has a given label. If not found, then it creates it in this step. Finally it updates the default setting values with the option group id and the value of this type. The option group id is mapped to `option-value-id` and the value is to `activity-type-id`.
+When the extension is installed, it creates the default setting. During the postInstall step, it searches for an activity type that has a given label. If not found, then it creates it in this step. The saved search is also created in this step. Finally it updates the default setting values with the saved search id, the option group id and the value of this type. The option group id is mapped to `option-value-id`, the value is to `activity-type-id` and the saved search id is mapped to `saved-search-id`.
 
 When the extension is enabled, it validates the setting values. In case of data corruption it creates the activity type again and updates the setting with the new values.
 
 When the extension is uninstalled, it deletes the settings. The activity type and the activities are not changed during the uninstall process.
+
+When the upgrade-db task is running, it checks for the existance of saved-search-id in the config. If it is not set or is on default value, it creates the saved search and updates the setting.

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2021-06-17</releaseDate>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="false" convertWarningsToExceptions="true" processIsolation="false" convertDeprecationsToExceptions="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="false" convertWarningsToExceptions="false" processIsolation="false" convertDeprecationsToExceptions="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Civi\Api4\OptionValue;
+use Civi\Api4\Contact;
+use Civi\Api4\Activity;
+
+/**
+ * Service class test cases.
+ *
+ * @group headless
+ */
+class CRM_Consentactivity_ServiceNotInstalledTest extends CRM_Consentactivity_HeadlessBase
+{
+    /*
+     * Overwrite setup function to skip the install of the current extenstion
+     * to be able to test the create steps of the service.
+     */
+    public function setUpHeadless()
+    {
+        return \Civi\Test::headless()
+            ->install('rc-base')
+            ->apply();
+    }
+
+    /**
+     * Test the createDefaultActivityType function.
+     */
+    public function testCreateDefaultActivityType()
+    {
+        $activityType = CRM_Consentactivity_Service::createDefaultActivityType();
+        self::assertIsArray($activityType);
+        self::assertSame(CRM_Consentactivity_Service::DEFAULT_CONSENT_ACTIVITY_TYPE_LABEL, $activityType['label']);
+        self::assertSame(CRM_Consentactivity_Service::DEFAULT_CONSENT_ACTIVITY_TYPE_ICON, $activityType['icon']);
+        self::assertTrue($activityType['is_active']);
+        self::assertTrue($activityType['is_reserved']);
+        // when we want to create the type again without changing the label, it will return the same;
+        $newActivityType = CRM_Consentactivity_Service::createDefaultActivityType();
+        // If the existing one is returned from this function, the list of the keys is
+        // extended, so that only those keys could be checked that were set in the original.
+        foreach ($activityType as $k => $v) {
+            self::assertSame($v, $newActivityType[$k]);
+        }
+        // Update the option value manually, then create again. The values has to be set back.
+        $result = OptionValue::update(false)
+            ->addWhere('id', '=', $activityType['id'])
+            ->addValue('is_active', false)
+            ->addValue('is_reserved', false)
+            ->execute()
+            ->first();
+        self::assertFalse($result['is_active']);
+        self::assertFalse($result['is_reserved']);
+        $newActivityType = CRM_Consentactivity_Service::createDefaultActivityType();
+        self::assertSame($activityType['id'], $newActivityType['id']);
+        $newActivityType = CRM_Consentactivity_Service::getActivityType($newActivityType['id']);
+        foreach ($activityType as $k => $v) {
+            self::assertSame($v, $newActivityType[$k]);
+        }
+    }
+
+    /**
+     * Test the postProcess function.
+     */
+    public function testPostProcessInvalidFormName()
+    {
+        $form = new CRM_Profile_Form_Edit();
+        $contact = Contact::create(false)
+            ->addValue('contact_type', 'Individual')
+            ->execute()
+            ->first();
+        $form->setVar('_id', $contact['id']);
+        $submit = [
+            'is_opt_out' => ''
+        ];
+        $form->setVar('_submitValues', $submit);
+        self::assertEmpty(CRM_Consentactivity_Service::postProcess('Not_Intrested_In_This_Class', $form), 'PostProcess supposed to be empty.');
+    }
+}

--- a/tests/phpunit/CRM/Consentactivity/ServiceTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceTest.php
@@ -11,75 +11,8 @@ use Civi\Api4\Activity;
  */
 class CRM_Consentactivity_ServiceTest extends CRM_Consentactivity_HeadlessBase
 {
-    /*
-     * Overwrite setup function to skip the install of the current extenstion
-     * to be able to test the create steps of the service.
-     */
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->install('rc-base')
-            ->apply();
-    }
-
-    /**
-     * Test the createDefaultActivityType function.
-     */
-    public function testCreateDefaultActivityType()
-    {
-        $activityType = CRM_Consentactivity_Service::createDefaultActivityType();
-        self::assertIsArray($activityType);
-        self::assertSame(CRM_Consentactivity_Service::DEFAULT_CONSENT_ACTIVITY_TYPE_LABEL, $activityType['label']);
-        self::assertSame(CRM_Consentactivity_Service::DEFAULT_CONSENT_ACTIVITY_TYPE_ICON, $activityType['icon']);
-        self::assertTrue($activityType['is_active']);
-        self::assertTrue($activityType['is_reserved']);
-        // when we want to create the type again without changing the label, it will return the same;
-        $newActivityType = CRM_Consentactivity_Service::createDefaultActivityType();
-        // If the existing one is returned from this function, the list of the keys is
-        // extended, so that only those keys could be checked that were set in the original.
-        foreach ($activityType as $k => $v) {
-            self::assertSame($v, $newActivityType[$k]);
-        }
-        // Update the option value manually, then create again. The values has to be set back.
-        $result = OptionValue::update(false)
-            ->addWhere('id', '=', $activityType['id'])
-            ->addValue('is_active', false)
-            ->addValue('is_reserved', false)
-            ->execute()
-            ->first();
-        self::assertFalse($result['is_active']);
-        self::assertFalse($result['is_reserved']);
-        $newActivityType = CRM_Consentactivity_Service::createDefaultActivityType();
-        self::assertSame($activityType['id'], $newActivityType['id']);
-        $newActivityType = CRM_Consentactivity_Service::getActivityType($newActivityType['id']);
-        foreach ($activityType as $k => $v) {
-            self::assertSame($v, $newActivityType[$k]);
-        }
-    }
-
-    /**
-     * Test the postProcess function.
-     */
-    public function testPostProcessInvalidFormName()
-    {
-        $form = new CRM_Profile_Form_Edit();
-        $contact = Contact::create(false)
-            ->addValue('contact_type', 'Individual')
-            ->execute()
-            ->first();
-        $form->setVar('_id', $contact['id']);
-        $submit = [
-            'is_opt_out' => ''
-        ];
-        $form->setVar('_submitValues', $submit);
-        self::assertEmpty(CRM_Consentactivity_Service::postProcess('Not_Intrested_In_This_Class', $form), 'PostProcess supposed to be empty.');
-    }
     public function testPostProcessMissingParameter()
     {
-        // enable extension
-        Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
         $form = new CRM_Profile_Form_Edit();
         $contact = Contact::create(false)
             ->addValue('contact_type', 'Individual')
@@ -96,10 +29,6 @@ class CRM_Consentactivity_ServiceTest extends CRM_Consentactivity_HeadlessBase
     }
     public function testPostProcessInvalidContactId()
     {
-        // enable extension
-        Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
         $form = new CRM_Profile_Form_Edit();
         $form->setVar('_id', 0);
         $submit = [
@@ -111,10 +40,6 @@ class CRM_Consentactivity_ServiceTest extends CRM_Consentactivity_HeadlessBase
     }
     public function testPostProcess()
     {
-        // enable extension
-        Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
         $form = new CRM_Profile_Form_Edit();
         $contact = Contact::create(false)
             ->addValue('contact_type', 'Individual')

--- a/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_Consentactivity_ExtensionUtil as E;
+
+/**
+ * Tests for the Upgrader process.
+ *
+ * @group headless
+ */
+class CRM_Consentactivity_UpgraderInstalledTest extends CRM_Consentactivity_HeadlessBase
+{
+
+    /**
+     * Test the upgrade_5000 process.
+     */
+    public function testUpgrade5000()
+    {
+        $config = new CRM_Consentactivity_Config(E::LONG_NAME);
+        $config->load();
+        $cfg = $config->get();
+        unset($cfg['saved-search-id']);
+        $config->update($cfg);
+        $installer = new CRM_Consentactivity_Upgrader(E::LONG_NAME, ".");
+        try {
+            $this->assertTrue($installer->upgrade_5000());
+        } catch (Exception $e) {
+            $this->fail("Should not throw exception. ".$e->getMessage());
+        }
+    }
+}

--- a/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
@@ -7,6 +7,16 @@
  */
 class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
 {
+    /*
+     * Overwrite setup function to skip the install of the current extenstion
+     * to be able to test the create steps of the service.
+     */
+    public function setUpHeadless()
+    {
+        return \Civi\Test::headless()
+            ->install('rc-base')
+            ->apply();
+    }
     /**
      * Test the install process.
      */
@@ -30,7 +40,7 @@ class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
             $this->assertEmpty($installer->install());
             $this->assertEmpty($installer->postInstall());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception.");
+            $this->fail("Should not throw exception. ".$e->getMessage());
         }
     }
 
@@ -45,7 +55,7 @@ class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
             $this->assertEmpty($installer->postInstall());
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception.");
+            $this->fail("Should not throw exception. ".$e->getMessage());
         }
     }
     public function testEnableCorruptInstall()
@@ -55,7 +65,7 @@ class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
             $this->assertEmpty($installer->install());
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception.");
+            $this->fail("Should not throw exception. ".$e->getMessage());
         }
     }
 
@@ -69,7 +79,7 @@ class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
         try {
             $this->assertEmpty($installer->uninstall());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception.");
+            $this->fail("Should not throw exception. ".$e->getMessage());
         }
     }
 }


### PR DESCRIPTION
- Option in the service for creating and getting saved search.
- Store saved search id in setting
- Add saved search on postInstall
- Handle corrupted saved search on enable
- db upgrade function for saved search
- Extend & refactor tests
- Update readme
- Bump version

For existing installations, the **upgrade-db** task has to be executed.