### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/consentactivity/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.5.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.6.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.38</ver>

--- a/tests/phpunit/CRM/Consentactivity/ConfigTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ConfigTest.php
@@ -3,8 +3,6 @@
 use Civi\Consentactivity\HeadlessTestCase;
 
 /**
- * Config class base test cases.
- *
  * @group headless
  */
 class CRM_Consentactivity_ConfigTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/ConfigTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ConfigTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\Consentactivity\HeadlessTestCase;
+
 /**
  * Config class base test cases.
  *
  * @group headless
  */
-class CRM_Consentactivity_ConfigTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_ConfigTest extends HeadlessTestCase
 {
     /**
      * It checks that the create function works well.

--- a/tests/phpunit/CRM/Consentactivity/Form/SettingsTest.php
+++ b/tests/phpunit/CRM/Consentactivity/Form/SettingsTest.php
@@ -4,8 +4,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * Settings form test cases.
- *
  * @group headless
  */
 class CRM_Consentactivity_Form_SettingsTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/Form/SettingsTest.php
+++ b/tests/phpunit/CRM/Consentactivity/Form/SettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
@@ -7,7 +8,7 @@ use CRM_Consentactivity_ExtensionUtil as E;
  *
  * @group headless
  */
-class CRM_Consentactivity_Form_SettingsTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_Form_SettingsTest extends HeadlessTestCase
 {
     private static function testDefaultSetting(): array
     {

--- a/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
+++ b/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
@@ -113,7 +113,7 @@ class CRM_Consentactivity_Page_ConsentRenewTest extends HeadlessTestCase
         self::assertSame(0, $result['is_error']);
         self::assertTrue(array_key_exists('id', $result), 'Missing id from the MailSettings update.');
         $result = civicrm_api3('Setting', 'create', [
-            'mailing_backend' => ["outBound_option" => 5, "smtpUsername" => "admin", "smtpPassword" => "admin"],
+            'mailing_backend' => ['outBound_option' => 5, 'smtpUsername' => 'admin', 'smtpPassword' => 'admin'],
         ]);
         self::assertSame(0, $result['is_error']);
         self::assertTrue(array_key_exists('id', $result), 'Missing id from the mailing_backend update.');
@@ -134,7 +134,7 @@ class CRM_Consentactivity_Page_ConsentRenewTest extends HeadlessTestCase
         $result = civicrm_api3('Mailing', 'create', [
             'subject' => 'email subject',
             'name' => 'email name',
-            'template_type' => "traditional",
+            'template_type' => 'traditional',
             'body_html' => '<div>{Consentactivity.consent_renewal}. {action.optOutUrl}. {domain.address}</div>',
             'body_text' => '{Consentactivity.consent_renewal}. {action.optOutUrl}. {domain.address}',
             'groups' => ['include' => [$groupId], 'exclude' => []],

--- a/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
+++ b/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
@@ -5,17 +5,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * It checks the opt out process.
- * Given:
- * - contact
- * - email
- * - group
- * - contact is added to the group
- * - mosaico message, with the group as include group
- * - process mailing jobs
- * When:
- * - call the easy-opt-out landing
- *
  * @group headless
  */
 class CRM_Consentactivity_Page_ConsentRenewTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
+++ b/tests/phpunit/CRM/Consentactivity/Page/ConsentRenewTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use CRM_Consentactivity_ExtensionUtil as E;
 use Civi\Api4\Activity;
+use Civi\Consentactivity\HeadlessTestCase;
+use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
  * It checks the opt out process.
@@ -17,7 +18,7 @@ use Civi\Api4\Activity;
  *
  * @group headless
  */
-class CRM_Consentactivity_Page_ConsentRenewTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_Page_ConsentRenewTest extends HeadlessTestCase
 {
     const DOMAIN_NAME = 'my-domain';
 

--- a/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Api4\Contact;
+use Civi\Consentactivity\HeadlessTestCase;
 use Civi\Test;
 
 /**
@@ -8,7 +9,7 @@ use Civi\Test;
  *
  * @group headless
  */
-class CRM_Consentactivity_ServiceNotInstalledTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_ServiceNotInstalledTest extends HeadlessTestCase
 {
     /*
      * Overwrite setup function to skip the install of the current extension

--- a/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceNotInstalledTest.php
@@ -5,8 +5,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use Civi\Test;
 
 /**
- * Service class test cases.
- *
  * @group headless
  */
 class CRM_Consentactivity_ServiceNotInstalledTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/ServiceTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceTest.php
@@ -18,8 +18,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * Service class test cases.
- *
  * @group headless
  */
 class CRM_Consentactivity_ServiceTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/ServiceTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceTest.php
@@ -15,12 +15,13 @@ use Civi\Api4\OptionValue;
 use Civi\Api4\Phone;
 use Civi\Api4\Website;
 use Civi\Consentactivity\HeadlessTestCase;
+use Civi\Test\TransactionalInterface;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
  * @group headless
  */
-class CRM_Consentactivity_ServiceTest extends HeadlessTestCase
+class CRM_Consentactivity_ServiceTest extends HeadlessTestCase implements TransactionalInterface
 {
     public function testPostProcessMissingParameter()
     {

--- a/tests/phpunit/CRM/Consentactivity/ServiceTest.php
+++ b/tests/phpunit/CRM/Consentactivity/ServiceTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use CRM_Consentactivity_ExtensionUtil as E;
 use Civi\Api4\Activity;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
@@ -15,13 +14,15 @@ use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
 use Civi\Api4\Phone;
 use Civi\Api4\Website;
+use Civi\Consentactivity\HeadlessTestCase;
+use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
  * Service class test cases.
  *
  * @group headless
  */
-class CRM_Consentactivity_ServiceTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_ServiceTest extends HeadlessTestCase
 {
     public function testPostProcessMissingParameter()
     {

--- a/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
@@ -18,11 +18,11 @@ class CRM_Consentactivity_UpgraderInstalledTest extends HeadlessTestCase
         $cfg = $config->get();
         unset($cfg['saved-search-id']);
         $config->update($cfg);
-        $installer = new CRM_Consentactivity_Upgrader(E::LONG_NAME, ".");
+        $installer = new CRM_Consentactivity_Upgrader();
         try {
             $this->assertTrue($installer->upgrade_5000());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
         // should do nothing.
         $config->load();
@@ -45,11 +45,11 @@ class CRM_Consentactivity_UpgraderInstalledTest extends HeadlessTestCase
         $cfg['saved-search-id'] = 10;
 
         $config->update($cfg);
-        $installer = new CRM_Consentactivity_Upgrader(E::LONG_NAME, ".");
+        $installer = new CRM_Consentactivity_Upgrader();
         try {
             $this->assertTrue($installer->upgrade_5100());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
         $config->load();
         $cfg = $config->get();
@@ -73,7 +73,7 @@ class CRM_Consentactivity_UpgraderInstalledTest extends HeadlessTestCase
         unset($cfg['consent-after-contribution']);
 
         $config->update($cfg);
-        $installer = new CRM_Consentactivity_Upgrader(E::LONG_NAME, ".");
+        $installer = new CRM_Consentactivity_Upgrader();
         self::assertTrue($installer->upgrade_5101());
         $config->load();
         $cfg = $config->get();

--- a/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
@@ -7,7 +8,7 @@ use CRM_Consentactivity_ExtensionUtil as E;
  *
  * @group headless
  */
-class CRM_Consentactivity_UpgraderInstalledTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_UpgraderInstalledTest extends HeadlessTestCase
 {
     /**
      * Test the upgrade_5000 process.

--- a/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderInstalledTest.php
@@ -4,8 +4,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * Tests for the Upgrader process.
- *
  * @group headless
  */
 class CRM_Consentactivity_UpgraderInstalledTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
@@ -16,7 +16,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->install());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception.");
+            $this->fail('Should not throw exception.');
         }
     }
 
@@ -31,7 +31,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
             $this->assertEmpty($installer->enable());
             $this->assertEmpty($installer->postInstall());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 
@@ -45,7 +45,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
             $this->assertEmpty($installer->install());
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 
@@ -63,7 +63,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 
@@ -84,7 +84,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 
@@ -102,7 +102,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 
@@ -122,7 +122,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
         $cfg->load();
         $config = $cfg->get();
@@ -147,7 +147,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->enable());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
         $cfg->load();
         $config = $cfg->get();
@@ -167,7 +167,7 @@ class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
         try {
             $this->assertEmpty($installer->uninstall());
         } catch (Exception $e) {
-            $this->fail("Should not throw exception. ".$e->getMessage());
+            $this->fail('Should not throw exception. '.$e->getMessage());
         }
     }
 }

--- a/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use Civi\Test;
+use Civi\Consentactivity\HeadlessTestCase;
 
 /**
  * Tests for the Upgrader process.
  *
  * @group headless
  */
-class CRM_Consentactivity_UpgraderTest extends CRM_Consentactivity_HeadlessBase
+class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase
 {
     /**
      * Test the install process.

--- a/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/Consentactivity/UpgraderTest.php
@@ -3,8 +3,6 @@
 use Civi\Consentactivity\HeadlessTestCase;
 
 /**
- * Tests for the Upgrader process.
- *
  * @group headless
  */
 class CRM_Consentactivity_UpgraderTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
@@ -2,9 +2,11 @@
 
 namespace Civi\Consentactivity;
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base class for headless tests.
@@ -12,12 +14,8 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-    public function setUpHeadless()
-    {
-    }
-
     /**
      * Apply a forced rebuild of DB, thus
      * create a clean DB before running tests
@@ -26,10 +24,17 @@ class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessIn
      */
     public static function setUpBeforeClass(): void
     {
-        // Resets DB and install depended extension
-        \Civi\Test::headless()
+        // Resets DB
+        Test::headless()
             ->install('rc-base')
             ->installMe(__DIR__)
             ->apply(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUpHeadless(): void
+    {
     }
 }

--- a/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
@@ -4,14 +4,12 @@ namespace Civi\Consentactivity;
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group headless
  */
-class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends TestCase implements HeadlessInterface
 {
     /**
      * Apply a forced rebuild of DB, thus

--- a/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
@@ -9,9 +9,6 @@ use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Base class for headless tests.
- * It implements the before and teardown functions
- *
  * @group headless
  */
 class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface

--- a/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Consentactivity/HeadlessTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Civi\Consentactivity;
+
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
@@ -10,7 +12,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_Consentactivity_HeadlessBase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
     public function setUpHeadless()
     {

--- a/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
@@ -4,7 +4,6 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\EntityTag;
 use Civi\Consentactivity\HeadlessTestCase;
-use Civi\Test\Api3TestTrait;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
@@ -12,8 +11,6 @@ use CRM_Consentactivity_ExtensionUtil as E;
  */
 class api_v3_ConsentactivityExpire_ProcessTest extends HeadlessTestCase
 {
-    use Api3TestTrait;
-
     /**
      * Test Process action without setting the search.
      * In this case it has to return 0 tagged contact

--- a/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
@@ -8,9 +8,6 @@ use Civi\Test\Api3TestTrait;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * ConsentactivityExpire.Process API Test Case
- * This is a generic test class implemented with PHPUnit.
- *
  * @group headless
  */
 class api_v3_ConsentactivityExpire_ProcessTest extends HeadlessTestCase

--- a/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityExpire/ProcessTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Civi\Api4\Activity;
+use Civi\Api4\Contact;
+use Civi\Api4\EntityTag;
+use Civi\Consentactivity\HeadlessTestCase;
 use Civi\Test\Api3TestTrait;
 use CRM_Consentactivity_ExtensionUtil as E;
-use Civi\Api4\Contact;
-use Civi\Api4\Activity;
-use Civi\Api4\EntityTag;
 
 /**
  * ConsentactivityExpire.Process API Test Case
@@ -12,7 +13,7 @@ use Civi\Api4\EntityTag;
  *
  * @group headless
  */
-class api_v3_ConsentactivityExpire_ProcessTest extends CRM_Consentactivity_HeadlessBase
+class api_v3_ConsentactivityExpire_ProcessTest extends HeadlessTestCase
 {
     use Api3TestTrait;
 

--- a/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
@@ -7,9 +7,6 @@ use Civi\Consentactivity\HeadlessTestCase;
 use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
- * ConsentactivityTagging.Process API Test Case
- * This is a generic test class implemented with PHPUnit.
- *
  * @group headless
  */
 class api_v3_ConsentactivityTagging_ProcessTest extends HeadlessTestCase

--- a/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
@@ -11,8 +11,6 @@ use CRM_Consentactivity_ExtensionUtil as E;
  */
 class api_v3_ConsentactivityTagging_ProcessTest extends HeadlessTestCase
 {
-    use \Civi\Test\Api3TestTrait;
-
     /**
      * Test Process action without setting the search.
      * In this case it has to return 0 tagged contact

--- a/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
+++ b/tests/phpunit/api/v3/ConsentactivityTagging/ProcessTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use CRM_Consentactivity_ExtensionUtil as E;
-use Civi\Api4\Contact;
 use Civi\Api4\Activity;
+use Civi\Api4\Contact;
 use Civi\Api4\EntityTag;
+use Civi\Consentactivity\HeadlessTestCase;
+use CRM_Consentactivity_ExtensionUtil as E;
 
 /**
  * ConsentactivityTagging.Process API Test Case
@@ -11,7 +12,7 @@ use Civi\Api4\EntityTag;
  *
  * @group headless
  */
-class api_v3_ConsentactivityTagging_ProcessTest extends CRM_Consentactivity_HeadlessBase
+class api_v3_ConsentactivityTagging_ProcessTest extends HeadlessTestCase
 {
     use \Civi\Test\Api3TestTrait;
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->add('CRM_', __DIR__);
 $loader->add('Civi\\', __DIR__);
 $loader->add('api_', __DIR__);
@@ -29,9 +31,9 @@ $loader->register();
 function cv($cmd, $decode = 'json')
 {
     $cmd = 'cv '.$cmd;
-    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
-    putenv("CV_OUTPUT=json");
+    putenv('CV_OUTPUT=json');
 
     // Execute `cv` in the original folder. This is a work-around for
     // phpunit/codeception, which seem to manipulate PWD.
@@ -51,8 +53,8 @@ function cv($cmd, $decode = 'json')
 
         case 'phpcode':
             // If the last output is /*PHPCODE*/, then we managed to complete execution.
-            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+                throw new RuntimeException("Command failed ($cmd):\n$result");
             }
 
             return $result;


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
